### PR TITLE
update go version to 1.21, improve example test, small docs update

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.20'  # Replace with your desired Go version (e.g., 1.16)
+          go-version: '1.21'  # Replace with your desired Go version (e.g., 1.16)
 
       - name: Run Go Tests
         run: go test ./...

--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ For coverage, it leverages the cover profiles for statements and function covera
 		log.Fatalln(err)
 	}
 
-	fmt.Println(stats.Count(), stats.Failed(), stats.Duration().String())
+	fmt.Printf("test count: %v failed: %v duration: %v\n", stats.Count(), stats.Failed(), stats.Duration().String())
 	pkg, _ := stats.Package("github.com/nickfiggins/tstat")
 	test, _ := pkg.Test("Test_CoverageStats")
-	fmt.Println(test.Count(), test.Failed(), test.Skipped(), test.Package)
+	fmt.Printf("%v/Test_CoverageStats count: %v failed: %v skipped: %v\n", test.Package, test.Count(), test.Failed(), test.Skipped())
 
 	sub, _ := test.Test("happy") // subtest Test_CoverageStats/happy
 	if !sub.Failed() {
 		fmt.Printf("%v passed\n", sub.FullName)
 	}
-	// Output: 50 false 473.097ms
-	// 3 false false github.com/nickfiggins/tstat
+	// Output: test count: 50 failed: false duration: 473.097ms
+	// github.com/nickfiggins/tstat/Test_CoverageStats count: 3 failed: false skipped: false
 	// Test_CoverageStats/happy passed
 ```

--- a/cover.go
+++ b/cover.go
@@ -74,21 +74,23 @@ func (pc *PackageCoverage) Functions() []FunctionCoverage {
 }
 
 func newPackageCoverage(stmts *gocover.PackageStatements) *PackageCoverage {
-	files := make(map[string]*FileCoverage)
+	files := make([]*FileCoverage, len(stmts.Files))
+	i := 0
 	for name, statements := range stmts.Files {
-		files[name] = &FileCoverage{
+		files[i] = &FileCoverage{
 			Name:         name,
 			Functions:    make([]FunctionCoverage, 0),
 			Percent:      statements.Percent,
 			Stmts:        int(statements.Stmts),
 			CoveredStmts: int(statements.CoveredStmts),
 		}
+		i++
 	}
 
 	return &PackageCoverage{
 		Name:    stmts.Package,
 		Percent: mathutil.Percent(stmts.CoveredStmts, stmts.Stmts),
-		Files:   maps.Values(files),
+		Files:   files,
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -32,16 +32,16 @@ func ExampleTests() {
 		log.Fatalln(err)
 	}
 
-	fmt.Println(stats.Count(), stats.Failed(), stats.Duration().String())
+	fmt.Printf("test count: %v failed: %v duration: %v\n", stats.Count(), stats.Failed(), stats.Duration().String())
 	pkg, _ := stats.Package("github.com/nickfiggins/tstat")
 	test, _ := pkg.Test("Test_CoverageStats")
-	fmt.Println(test.Count(), test.Failed(), test.Skipped(), test.Package)
+	fmt.Printf("%v/Test_CoverageStats count: %v failed: %v skipped: %v\n", test.Package, test.Count(), test.Failed(), test.Skipped())
 
 	sub, _ := test.Test("happy") // subtest Test_CoverageStats/happy
 	if !sub.Failed() {
 		fmt.Printf("%v passed\n", sub.FullName)
 	}
-	// Output: 50 false 473.097ms
-	// 3 false false github.com/nickfiggins/tstat
+	// Output: test count: 50 failed: false duration: 473.097ms
+	// github.com/nickfiggins/tstat/Test_CoverageStats count: 3 failed: false skipped: false
 	// Test_CoverageStats/happy passed
 }

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/nickfiggins/tstat
 
-go 1.20
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.8.2
-	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
-	golang.org/x/tools v0.8.0
+	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
+	golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -12,10 +12,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
-golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
-golang.org/x/tools v0.8.0 h1:vSDcovVPld282ceKgDimkRSC8kpaH1dgyc9UMzlt84Y=
-golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
+golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
+golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
+golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846 h1:Vve/L0v7CXXuxUmaMGIEK/dEeq7uiqb5qBgQrZzIE7E=
+golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test_runs.go
+++ b/test_runs.go
@@ -16,8 +16,9 @@ func (tr *TestRun) Packages() []PackageRun {
 	return tr.pkgs
 }
 
-// PackageRun represents the results of a package test run. If the package was run with the -shuffle flag,
-// the Seed field will be populated. Otherwise, it will be 0.
+// Package returns a PackageRun for the package with the given name, if any data was
+// recorded for it during the test run. If the package isn't found, false is returned
+// as the second argument.
 func (tr *TestRun) Package(name string) (PackageRun, bool) {
 	for _, pkg := range tr.pkgs {
 		if strings.EqualFold(name, pkg.pkgName) {
@@ -27,6 +28,7 @@ func (tr *TestRun) Package(name string) (PackageRun, bool) {
 	return PackageRun{}, false
 }
 
+// Duration returns the duration of the TestRun.
 func (tr *TestRun) Duration() time.Duration {
 	return tr.end.Sub(tr.start)
 }
@@ -59,13 +61,13 @@ func (pr *PackageRun) Test(name string) (*Test, bool) {
 }
 
 func findTest(name string, tests ...*Test) (*Test, bool) {
-	for _, t := range tests {
-		if strings.EqualFold(t.Name, name) {
-			return t, true
+	for _, test := range tests {
+		if strings.EqualFold(test.Name, name) {
+			return test, true
 		}
 
-		if t.looksLikeSub(name) {
-			if sub, ok := findTest(name, t.Subtests...); ok {
+		if test.looksLikeSub(name) {
+			if sub, ok := findTest(name, test.Subtests...); ok {
 				return sub, true
 			}
 		}
@@ -73,7 +75,8 @@ func findTest(name string, tests ...*Test) (*Test, bool) {
 	return nil, false
 }
 
-// PackageRun represents the results of a package test run. If the package was run with the -shuffle flag,.
+// PackageRun represents the results of a package test run. If the package was run with the -shuffle flag,
+// the Seed field will be populated. Otherwise, it will be 0.
 type PackageRun struct {
 	pkgName    string
 	start, end time.Time

--- a/tests.go
+++ b/tests.go
@@ -4,8 +4,9 @@ import (
 	"strings"
 	"time"
 
+	"slices"
+
 	"github.com/nickfiggins/tstat/internal/gotest"
-	"golang.org/x/exp/slices"
 )
 
 // Test is a single test, which may have subtests.


### PR DESCRIPTION
- upgrade Go to 1.21 and replace exp slices package with the std library
- improve print statements in example test
- fix doc issues